### PR TITLE
chore: configure all-contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -15,13 +15,6 @@
       "avatar_url": "https://avatars0.githubusercontent.com/u/450495?v=4",
       "profile": "https://andrewjtorr.es",
       "contributions": ["code", "doc", "infra"]
-    },
-    {
-      "login": "brian-dlee",
-      "name": "Brian Lee",
-      "avatar_url": "https://avatars0.githubusercontent.com/u/15238587?v=4",
-      "profile": "https://github.com/brian-dlee",
-      "contributions": ["doc"]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,27 @@
+{
+  "projectName": "marvin",
+  "projectOwner": "ajtorres9",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": ["readme.md"],
+  "imageSize": 100,
+  "commit": false,
+  "contributorsPerLine": 7,
+  "badgeTemplate": "  <a href=\"#contributors\"><img alt=\"All Contributors\" src=\"https://flat.badgen.net/badge/all%20contributors/<%= contributors.length %>/orange\"></a>",
+  "contributors": [
+    {
+      "login": "ajtorres9",
+      "name": "Andrew Torres",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/450495?v=4",
+      "profile": "https://andrewjtorr.es",
+      "contributions": ["code", "doc", "infra"]
+    },
+    {
+      "login": "brian-dlee",
+      "name": "Brian Lee",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/15238587?v=4",
+      "profile": "https://github.com/brian-dlee",
+      "contributions": ["doc"]
+    }
+  ]
+}

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
   The artificial intelligence afflicted with severe depression and boredom
 </p>
 <p align="center">
-  <a href="#contributors"><img alt="All Contributors" src="https://flat.badgen.net/badge/all%20contributors/2/orange"></a>
+  <a href="#contributors"><img alt="All Contributors" src="https://flat.badgen.net/badge/all%20contributors/1/orange"></a>
   <a href="https://github.com/commitizen/cz-cli"><img alt="Commitizen" src="https://flat.badgen.net/badge/commitizen/friendly/green"></a>
   <a href="license"><img alt="License" src="https://flat.badgen.net/github/license/ajtorres9/marvin"></a>
 </p>
@@ -16,8 +16,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars0.githubusercontent.com/u/450495?v=4" width="100px;" alt="Andrew Torres"/><br /><sub><b>Andrew Torres</b></sub>](https://andrewjtorr.es)<br />[💻](https://github.com/ajtorres9/marvin/commits?author=ajtorres9 "Code") [📖](https://github.com/ajtorres9/marvin/commits?author=ajtorres9 "Documentation") [🚇](#infra-ajtorres9 "Infrastructure (Hosting, Build-Tools, etc)") | [<img src="https://avatars0.githubusercontent.com/u/15238587?v=4" width="100px;" alt="Brian Lee"/><br /><sub><b>Brian Lee</b></sub>](https://andrewjtorr.es)<br />[📖](https://github.com/ajtorres9/marvin/commits?author=brian-dlee "Documentation") |
-| :---: | :---: |
+| [<img src="https://avatars0.githubusercontent.com/u/450495?v=4" width="100px;" alt="Andrew Torres"/><br /><sub><b>Andrew Torres</b></sub>](https://andrewjtorr.es)<br />[💻](https://github.com/ajtorres9/marvin/commits?author=ajtorres9 "Code") [📖](https://github.com/ajtorres9/marvin/commits?author=ajtorres9 "Documentation") [🚇](#infra-ajtorres9 "Infrastructure (Hosting, Build-Tools, etc)") |
+| :---: |
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/readme.md
+++ b/readme.md
@@ -14,12 +14,12 @@
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
+<!-- prettier-ignore-start -->
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore -->
 | [<img src="https://avatars0.githubusercontent.com/u/450495?v=4" width="100px;" alt="Andrew Torres"/><br /><sub><b>Andrew Torres</b></sub>](https://andrewjtorr.es)<br />[💻](https://github.com/ajtorres9/marvin/commits?author=ajtorres9 "Code") [📖](https://github.com/ajtorres9/marvin/commits?author=ajtorres9 "Documentation") [🚇](#infra-ajtorres9 "Infrastructure (Hosting, Build-Tools, etc)") |
 | :---: |
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+<!-- prettier-ignore-end -->
 
 This project follows the [all-contributors](https://allcontributors.org) specification. Contributions of any kind are welcome!
 

--- a/readme.md
+++ b/readme.md
@@ -5,9 +5,23 @@
   The artificial intelligence afflicted with severe depression and boredom
 </p>
 <p align="center">
+  <a href="#contributors"><img alt="All Contributors" src="https://flat.badgen.net/badge/all%20contributors/2/orange"></a>
   <a href="https://github.com/commitizen/cz-cli"><img alt="Commitizen" src="https://flat.badgen.net/badge/commitizen/friendly/green"></a>
   <a href="license"><img alt="License" src="https://flat.badgen.net/github/license/ajtorres9/marvin"></a>
 </p>
+
+## Contributors
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore -->
+| [<img src="https://avatars0.githubusercontent.com/u/450495?v=4" width="100px;" alt="Andrew Torres"/><br /><sub><b>Andrew Torres</b></sub>](https://andrewjtorr.es)<br />[💻](https://github.com/ajtorres9/marvin/commits?author=ajtorres9 "Code") [📖](https://github.com/ajtorres9/marvin/commits?author=ajtorres9 "Documentation") [🚇](#infra-ajtorres9 "Infrastructure (Hosting, Build-Tools, etc)") | [<img src="https://avatars0.githubusercontent.com/u/15238587?v=4" width="100px;" alt="Brian Lee"/><br /><sub><b>Brian Lee</b></sub>](https://andrewjtorr.es)<br />[📖](https://github.com/ajtorres9/marvin/commits?author=brian-dlee "Documentation") |
+| :---: | :---: |
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://allcontributors.org) specification. Contributions of any kind are welcome!
 
 ## License
 


### PR DESCRIPTION
This PR adds the [`all-contributors`](https://allcontributors.org/) config and section to the root readme