### PR TITLE
docs: add code of conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,72 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, sex characteristics, gender identity, and
+expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account or acting as an appointed
+representative at an online or offline event. Representation of a project may
+be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing or otherwise, unacceptable behavior may be
+reported by contacting Andrew Torres <andrew.jonathan.torres@gmail.com> or
+Brian Lee <briandl92391@gmail.com>. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/packages/ai/readme.md
+++ b/packages/ai/readme.md
@@ -11,10 +11,13 @@ Dependencies in this package are maintained by [Poetry](https://poetry.eustace.i
 Install poetry using the default python interpreter.
 
 ```shell
-curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
+curl --location --show-error --silent https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
 ```
 
-If you are not using the default python intepreter the above step won't work as it assumes you want to use the interpreter named `python`. Instead, you can install using the version of pip that is coupled with your alternate interpreter.
+If you are not using the default python interpreter the above step won't work
+as it assumes you want to use the interpreter named `python`. Instead, you can
+install using the version of pip that is coupled with your alternate
+interpreter.
 
 In many cases, we want to install `poetry` to be used with `python3`.
 

--- a/readme.md
+++ b/readme.md
@@ -5,9 +5,15 @@
   The artificial intelligence afflicted with severe depression and boredom
 </p>
 <p align="center">
-  <a href="#contributors"><img alt="All Contributors" src="https://flat.badgen.net/badge/all%20contributors/2/orange"></a>
-  <a href="https://github.com/commitizen/cz-cli"><img alt="Commitizen" src="https://flat.badgen.net/badge/commitizen/friendly/green"></a>
-  <a href="license"><img alt="License" src="https://flat.badgen.net/github/license/ajtorres9/marvin"></a>
+  <a href="#contributors">
+    <img alt="All Contributors" src="https://flat.badgen.net/badge/all%20contributors/2/orange">
+  </a>
+  <a href="https://github.com/commitizen/cz-cli">
+    <img alt="Commitizen" src="https://flat.badgen.net/badge/commitizen/friendly/green">
+  </a>
+  <a href="license">
+    <img alt="License" src="https://flat.badgen.net/github/license/ajtorres9/marvin">
+  </a>
 </p>
 
 ## Contributors
@@ -21,7 +27,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://allcontributors.org) specification. Contributions of any kind are welcome!
+This project follows the [all-contributors](https://allcontributors.org)
+specification. Contributions of any kind are welcome!
 
 ## License
 


### PR DESCRIPTION
This PR adds a `code-of-conduct.md` file to the root of the repository